### PR TITLE
support pipx install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 __pycache__/
 *.egg-info/
+.venv/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hello_tls"
-version = "0.3.2"
+version = "0.3.3"
 authors = [
   { name="BoppreH", email="github@boppreh.com" },
 ]
@@ -19,6 +19,9 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+
+[project.scripts]
+hello_tls = "hello_tls.__main__:main"
 
 [project.urls]
 "Homepage" = "https://github.com/boppreh/hello_tls"

--- a/src/hello_tls/__main__.py
+++ b/src/hello_tls/__main__.py
@@ -7,63 +7,69 @@ import sys
 import json
 import logging
 import argparse
-parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-parser.add_argument("target", help="server to scan, in the form of 'example.com', 'example.com:443', or even a full URL")
-parser.add_argument("--timeout", "-t", dest="timeout", type=float, default=DEFAULT_TIMEOUT, help="socket connection timeout in seconds")
-parser.add_argument("--max-workers", "-w", type=int, default=DEFAULT_MAX_WORKERS, help="maximum number of threads/concurrent connections to use for scanning")
-parser.add_argument("--server-name-indication", "-s", default='', help="value to be used in the SNI extension, defaults to the target host")
-parser.add_argument("--certs", "-c", default=True, action=argparse.BooleanOptionalAction, help="fetch the certificate chain using pyOpenSSL")
-parser.add_argument("--enumerate-cipher-suites", "-C", dest='enumerate_cipher_suites', default=True, action=argparse.BooleanOptionalAction, help="enumerate supported cipher suites")
-parser.add_argument("--enumerate-groups", "-G", dest='enumerate_groups', default=True, action=argparse.BooleanOptionalAction, help="enumerate supported groups")
-parser.add_argument("--protocols", "-p", dest='protocols_str', default=','.join(p.name for p in Protocol), help="comma separated list of TLS/SSL protocols to test")
-parser.add_argument("--proxy", default=None, help="HTTP proxy to use for the connection, defaults to the env variable 'http_proxy' else no proxy")
-parser.add_argument("--verbose", "-v", action="count", default=0, help="increase output verbosity")
-parser.add_argument("--progress", default=False, action=argparse.BooleanOptionalAction, help="write lines with progress percentages to stderr")
-args = parser.parse_args()
 
-logging.basicConfig(
-    datefmt='%Y-%m-%d %H:%M:%S',
-    format='{asctime}.{msecs:0<3.0f} {module} {threadName} {levelname}: {message}',
-    style='{',
-    level=[logging.WARNING, logging.INFO, logging.DEBUG][min(2, args.verbose)]
-)
 
-if not args.protocols_str:
-    parser.error("no protocols to test")
-try:
-    protocols = [Protocol[p] for p in args.protocols_str.split(',')]
-except KeyError as e:
-    parser.error(f'invalid protocol name "{e.args[0]}", must be one of {", ".join(p.name for p in Protocol)}')
+def main():
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("target", help="server to scan, in the form of 'example.com', 'example.com:443', or even a full URL")
+    parser.add_argument("--timeout", "-t", dest="timeout", type=float, default=DEFAULT_TIMEOUT, help="socket connection timeout in seconds")
+    parser.add_argument("--max-workers", "-w", type=int, default=DEFAULT_MAX_WORKERS, help="maximum number of threads/concurrent connections to use for scanning")
+    parser.add_argument("--server-name-indication", "-s", default='', help="value to be used in the SNI extension, defaults to the target host")
+    parser.add_argument("--certs", "-c", default=True, action=argparse.BooleanOptionalAction, help="fetch the certificate chain using pyOpenSSL")
+    parser.add_argument("--enumerate-cipher-suites", "-C", dest='enumerate_cipher_suites', default=True, action=argparse.BooleanOptionalAction, help="enumerate supported cipher suites")
+    parser.add_argument("--enumerate-groups", "-G", dest='enumerate_groups', default=True, action=argparse.BooleanOptionalAction, help="enumerate supported groups")
+    parser.add_argument("--protocols", "-p", dest='protocols_str', default=','.join(p.name for p in Protocol), help="comma separated list of TLS/SSL protocols to test")
+    parser.add_argument("--proxy", default=None, help="HTTP proxy to use for the connection, defaults to the env variable 'http_proxy' else no proxy")
+    parser.add_argument("--verbose", "-v", action="count", default=0, help="increase output verbosity")
+    parser.add_argument("--progress", default=False, action=argparse.BooleanOptionalAction, help="write lines with progress percentages to stderr")
+    args = parser.parse_args()
 
-host, port = parse_target(args.target)
+    logging.basicConfig(
+        datefmt='%Y-%m-%d %H:%M:%S',
+        format='{asctime}.{msecs:0<3.0f} {module} {threadName} {levelname}: {message}',
+        style='{',
+        level=[logging.WARNING, logging.INFO, logging.DEBUG][min(2, args.verbose)]
+    )
 
-if args.certs and protocols == [Protocol.SSLv3]:
-    parser.error("SSLv3 is not supported by pyOpenSSL, so `--protocols SSLv3` must be used with `--no-certs`")
+    if not args.protocols_str:
+        parser.error("no protocols to test")
+    try:
+        protocols = [Protocol[p] for p in args.protocols_str.split(',')]
+    except KeyError as e:
+        parser.error(f'invalid protocol name "{e.args[0]}", must be one of {", ".join(p.name for p in Protocol)}')
 
-proxy = os.environ.get('https_proxy') or os.environ.get('HTTPS_PROXY') if args.proxy is None else args.proxy
+    host, port = parse_target(args.target)
 
-if args.progress:
-    progress = lambda current, total: print(f'{current/total:.0%}', flush=True, file=sys.stderr)
-    print('0%', flush=True, file=sys.stderr)
-else:
-    progress = lambda current, total: None
+    if args.certs and protocols == [Protocol.SSLv3]:
+        parser.error("SSLv3 is not supported by pyOpenSSL, so `--protocols SSLv3` must be used with `--no-certs`")
 
-results = scan_server(
-    ConnectionSettings(
-        host=host,
-        port=port,
-        proxy=proxy,
-        timeout_in_seconds=args.timeout
-    ),
-    ClientHello(
-        protocols=protocols,
-        server_name=args.server_name_indication or host
-    ),
-    do_enumerate_cipher_suites=args.enumerate_cipher_suites,
-    do_enumerate_groups=args.enumerate_groups,
-    fetch_cert_chain=args.certs,
-    max_workers=args.max_workers,
-    progress=progress,
-)
+    proxy = os.environ.get('https_proxy') or os.environ.get('HTTPS_PROXY') if args.proxy is None else args.proxy
 
-json.dump(to_json_obj(results), sys.stdout, indent=2)
+    if args.progress:
+        progress = lambda current, total: print(f'{current/total:.0%}', flush=True, file=sys.stderr)
+        print('0%', flush=True, file=sys.stderr)
+    else:
+        progress = lambda current, total: None
+
+    results = scan_server(
+        ConnectionSettings(
+            host=host,
+            port=port,
+            proxy=proxy,
+            timeout_in_seconds=args.timeout
+        ),
+        ClientHello(
+            protocols=protocols,
+            server_name=args.server_name_indication or host
+        ),
+        do_enumerate_cipher_suites=args.enumerate_cipher_suites,
+        do_enumerate_groups=args.enumerate_groups,
+        fetch_cert_chain=args.certs,
+        max_workers=args.max_workers,
+        progress=progress,
+    )
+
+    json.dump(to_json_obj(results), sys.stdout, indent=2)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
By installing this with `pipx install hello-tls` I can avoid pulling the pyOpenSSL dependency into my global dependencies.

I had to expose a callable `main() `function from the `__main__`  module following the advice here https://stackoverflow.com/questions/27784271/how-can-i-use-setuptools-to-generate-a-console-scripts-entry-point-which-calls as trying to call the __main__ module directly results in `TypeError: 'module' object is not callable`.

I tested this with test.pypi.org https://test.pypi.org/project/hello-tls-ben/:

```
python -m build
twine upload --repository-url https://test.pypi.org/legacy/ --username __token__ --password pypi-AgENdGVzdC5weXBpLm9yZwIkOWFjOWVlMTctYmUxZS00MmUzLTkyOWItOWNjZjBhYWEzNzc0AAIqWzMsImIxYjY3MWIzLWM0MDgtNDZhZi04OGJiLWYwNjlkNGEyMzBmMCJdAAAGIMx2j3U_it_jbE7jbAYvcZy3JyH_Xe_6Zof1qdvfwyd3 dist/*

pipx install --index-url https://test.pypi.org/simple --pip-args="--extra-index-url https://pypi.org/simple/" hello-tls-ben==0.3.17