### PR TITLE
An OpenSSL.crypto.Error occurs when a certificate contains an extension not known to OpenSSL 

### DIFF
--- a/src/hello_tls/scan.py
+++ b/src/hello_tls/scan.py
@@ -217,7 +217,11 @@ def get_server_certificate_chain(connection_settings: ConnectionSettings, client
         extensions: dict[str, str] = {}
         for i in range(raw_cert.get_extension_count()):
             extension = raw_cert.get_extension(i)
-            extensions[extension.get_short_name().decode('utf-8')] = str(extension)
+            try:
+                value = str(extension)
+            except:
+                value = extension.get_data().hex(':')
+            extensions[extension.get_short_name().decode('utf-8')] = value
 
         san = re.findall(r'DNS:(.+?)(?:, |$)', extensions.get('subjectAltName', ''))
 

--- a/src/hello_tls/scan.py
+++ b/src/hello_tls/scan.py
@@ -219,7 +219,7 @@ def get_server_certificate_chain(connection_settings: ConnectionSettings, client
             extension = raw_cert.get_extension(i)
             try:
                 value = str(extension)
-            except:
+            except crypto.Error:
                 value = extension.get_data().hex(':')
             extensions[extension.get_short_name().decode('utf-8')] = value
 


### PR DESCRIPTION
The problem occurs e.g. with ey.com and office365.com

The proposed fix is to catch the error and show the extension in hex. 

It is not ideal, as the extension name is shown `UNDEF` instead of the object ID. I regard this as an deficiency of the `X509Extension` class and didn't find an easy way around.

