### PR TITLE
Accept TLS alert close_notify after client hello to indicate incompatible parameters

### DIFF
--- a/src/hello_tls/scan.py
+++ b/src/hello_tls/scan.py
@@ -111,7 +111,7 @@ def _iterate_server_option(connection_settings: ConnectionSettings, client_hello
         except DowngradeError:
             break
         except ServerAlertError as error:
-            if error.description in [AlertDescription.protocol_version, AlertDescription.handshake_failure]:
+            if error.description in [AlertDescription.protocol_version, AlertDescription.handshake_failure, AlertDescription.close_notify]:
                 break
             raise
 


### PR DESCRIPTION
Some TLS servers seem to  indicate incompatible parameters with close_notify instead of protocol_version or handshake_failure.

Observed on ~13% of 1000 servers tests, e.g. on AWS hosted sites like bloomberg.com